### PR TITLE
Feature/nuclear capacities bug fix

### DIFF
--- a/config/config.form.yaml
+++ b/config/config.form.yaml
@@ -10,10 +10,6 @@ logging:
   level: INFO
   format: '%(levelname)s:%(name)s:%(message)s'
 
-remote:
-  ssh: ""
-  path: ""
-
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
   prefix: "initial_main_scenarios"
@@ -126,6 +122,16 @@ transmission_projects:
     #- planned_not_yet_permitted
     #- under_consideration
   new_link_capacity: zero #keep or zero
+
+pypsa_eur:
+  Generator:
+  - onwind
+  - offwind-ac
+  - offwind-dc
+  - offwind-float
+  - solar-hsat
+  - solar
+  - ror
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#existing-capacities
 # TODO: add option for manual phase out of conventional power plants

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -330,6 +330,7 @@ def add_power_capacities_installed_before_baseyear(n, grouping_years, costs, bas
                         capital_cost=costs.at[generator, "efficiency"]
                         * costs.at[generator, "fixed"],  # NB: fixed cost is per MWel
                         p_nom=new_capacity / costs.at[generator, "efficiency"],
+                        p_max_pu=0.7 if generator == "nuclear" else 1,  # be conservative for nuclear (maintance or unplanned shut downs)
                         efficiency=costs.at[generator, "efficiency"],
                         efficiency2=costs.at[carrier[generator], "CO2 intensity"],
                         build_year=grouping_year,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -518,7 +518,7 @@ def add_carrier_buses(n, carrier, nodes=None):
     )
 
     fossils = ["coal", "gas", "oil", "lignite"]
-    if options["fossil_fuels"] and carrier in fossils:
+    if (options["fossil_fuels"] and carrier in fossils) or (carrier == "uranium"):
         suffix = ""
 
         if carrier == "oil" and cf_industry["oil_refining_emissions"] > 0:


### PR DESCRIPTION
Closes #27.

With fixed nuclear capacities the installed capacities for the project scope look like this:
![image](https://github.com/user-attachments/assets/01b9c147-464a-41cd-97f0-e6dc25ca55c2)

An additional bug fix was necessary to enable the use of links for nuclear power plants as a generator for uranium was missing at the uranium fuel bus.


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changes in configuration options are added in `config/config.default.yaml`.