### PR TITLE
Add a constraint to limit DAC

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -615,9 +615,13 @@ sector:
   methanation: true
   coal_cc: false
   dac: true
-  dac_limit:
+  dac_limit:  # limit in MtCO2, default pathway is based on EC Industrial Carbon Management (COM/2024/62) https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:52024DC0062
     enable: false
-    2035: 20  # limit in MtCO2
+    2030: 0
+    2035: 20  # interpolated value for DAC share and total captured carbon
+    2040: 70
+    2045: 137  # interpolated value for DAC share and total captured carbon
+    2050: 180
   co2_vent: false
   central_heat_vent: false
   allam_cycle_gas: false

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -615,7 +615,9 @@ sector:
   methanation: true
   coal_cc: false
   dac: true
-  dac_limit: false  # false or limit in MtCO2
+  dac_limit:
+    enable: false
+    2035: 20  # limit in MtCO2
   co2_vent: false
   central_heat_vent: false
   allam_cycle_gas: false

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -615,6 +615,7 @@ sector:
   methanation: true
   coal_cc: false
   dac: true
+  dac_limit: false  # false or limit in MtCO2
   co2_vent: false
   central_heat_vent: false
   allam_cycle_gas: false

--- a/config/config.form.yaml
+++ b/config/config.form.yaml
@@ -182,7 +182,7 @@ sector:
   tes: false
   dac: true
   dac_limit:
-      enable: False
+      enable: false
       2035: 20  # limit in MtCO2
   marginal_cost_storage: 0. #1e-4
   stores: ["H2"]

--- a/config/config.form.yaml
+++ b/config/config.form.yaml
@@ -13,7 +13,7 @@ logging:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
   prefix: "updated_initial_main_scenarios"
-  name: "main-mds-vanilla-no-methanation"
+  name: "main-mds-vanilla-dac-limit-ev40"
   scenarios:
     enable: true
     file: config/scenarios.form.yaml
@@ -180,6 +180,8 @@ sector:
   reduce_space_heat_exogenously_factor: # TODO: check this for Germany (Regulation or Ariadne?)
     2035: 0.11
   tes: false
+  dac: true
+  dac_limit: false  # False or limit in MtCO2
   marginal_cost_storage: 0. #1e-4
   stores: ["H2"]
   storage_units: ["li-ion battery", "vanadium", "lair", "pair", "iron-air battery"]

--- a/config/config.form.yaml
+++ b/config/config.form.yaml
@@ -181,7 +181,9 @@ sector:
     2035: 0.11
   tes: false
   dac: true
-  dac_limit: false  # False or limit in MtCO2
+  dac_limit:
+      enable: False
+      2035: 20  # limit in MtCO2
   marginal_cost_storage: 0. #1e-4
   stores: ["H2"]
   storage_units: ["li-ion battery", "vanadium", "lair", "pair", "iron-air battery"]

--- a/config/scenarios.form.yaml
+++ b/config/scenarios.form.yaml
@@ -94,7 +94,9 @@ main-mds-vanilla-dac-limit-ev35:
     stores: ["H2"]
     storage_units: ["li-ion battery", "iron-air battery"]
     dac: true
-    dac_limit: 20  # False or limit in MtCO2
+    dac_limit:
+        enable: true
+        2035: 20  # limit in MtCO2
 
 main-mds-vanilla-dac-limit-ev40:
   electricity:
@@ -113,7 +115,9 @@ main-mds-vanilla-dac-limit-ev40:
     stores: ["H2"]
     storage_units: ["li-ion battery", "iron-air battery"]
     dac: true
-    dac_limit: 20  # False or limit in MtCO2
+    dac_limit:
+        enable: true
+        2035: 20  # limit in MtCO2
 
 main-mds-vanilla-dac-limit-ev45:
   electricity:
@@ -132,7 +136,9 @@ main-mds-vanilla-dac-limit-ev45:
     stores: ["H2"]
     storage_units: ["li-ion battery", "iron-air battery"]
     dac: true
-    dac_limit: 20  # False or limit in MtCO2
+    dac_limit:
+        enable: true
+        2035: 20  # limit in MtCO2
 
 main-mds-vanilla-dac-limit-ev45-nuc80:
   electricity:
@@ -151,7 +157,9 @@ main-mds-vanilla-dac-limit-ev45-nuc80:
     stores: ["H2"]
     storage_units: ["li-ion battery", "iron-air battery"]
     dac: true
-    dac_limit: 20  # False or limit in MtCO2
+    dac_limit:
+        enable: true
+        2035: 20  # limit in MtCO2
   conventional:
     nuclear:
       p_min_pu: 0.8

--- a/config/scenarios.form.yaml
+++ b/config/scenarios.form.yaml
@@ -77,6 +77,85 @@ main-mds-vanilla:
     stores: ["H2"]
     storage_units: ["li-ion battery", "iron-air battery"]
 
+main-mds-vanilla-dac-limit-ev35:
+  electricity:
+    max_hours:
+      li-ion battery: [1, 2, 4, 8]
+      vanadium: [10]
+      lair: [12]
+      pair: [24]
+      H2: [168]
+      iron-air battery: [100]
+  sector:
+    land_transport_electric_share:
+      2035: 0.35 # default assumptions
+    land_transport_ice_share:
+      2035: 0.65
+    stores: ["H2"]
+    storage_units: ["li-ion battery", "iron-air battery"]
+    dac: true
+    dac_limit: 20  # False or limit in MtCO2
+
+main-mds-vanilla-dac-limit-ev40:
+  electricity:
+    max_hours:
+      li-ion battery: [1, 2, 4, 8]
+      vanadium: [10]
+      lair: [12]
+      pair: [24]
+      H2: [168]
+      iron-air battery: [100]
+  sector:
+    land_transport_electric_share:
+      2035: 0.40 # default assumptions
+    land_transport_ice_share:
+      2035: 0.60
+    stores: ["H2"]
+    storage_units: ["li-ion battery", "iron-air battery"]
+    dac: true
+    dac_limit: 20  # False or limit in MtCO2
+
+main-mds-vanilla-dac-limit-ev45:
+  electricity:
+    max_hours:
+      li-ion battery: [1, 2, 4, 8]
+      vanadium: [10]
+      lair: [12]
+      pair: [24]
+      H2: [168]
+      iron-air battery: [100]
+  sector:
+    land_transport_electric_share:
+      2035: 0.45 # default assumptions
+    land_transport_ice_share:
+      2035: 0.55
+    stores: ["H2"]
+    storage_units: ["li-ion battery", "iron-air battery"]
+    dac: true
+    dac_limit: 20  # False or limit in MtCO2
+
+main-mds-vanilla-dac-limit-ev45-nuc80:
+  electricity:
+    max_hours:
+      li-ion battery: [1, 2, 4, 8]
+      vanadium: [10]
+      lair: [12]
+      pair: [24]
+      H2: [168]
+      iron-air battery: [100]
+  sector:
+    land_transport_electric_share:
+      2035: 0.45 # default assumptions
+    land_transport_ice_share:
+      2035: 0.55
+    stores: ["H2"]
+    storage_units: ["li-ion battery", "iron-air battery"]
+    dac: true
+    dac_limit: 20  # False or limit in MtCO2
+  conventional:
+    nuclear:
+      p_min_pu: 0.8
+
 main-no-mds-vanilla:
   electricity:
     max_hours:

--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -105,7 +105,8 @@ storage_units,--,List of storage technologies to include as StorageUnit componen
 methanation,--,"{true, false}",Add option for transforming hydrogen and CO2 into methane using methanation.
 coal_cc,--,"{true, false}",Add option for coal CHPs with carbon capture
 dac,--,"{true, false}",Add option for Direct Air Capture (DAC)
-dac_limit,--,float or false,Add limit on Direct Air Capture (DAC). Can be either false or limit in MtCO2.
+dac_limit,MtCO2,Dictionary with planning horizons as keys.,Limit on Direct Air Capture (DAC) in MtCO2.
+-- enable,--,"{true, false}",Add limit on Direct Air Capture (DAC).
 co2_vent,--,"{true, false}",Add option for vent out CO2 from storages to the atmosphere.
 allam_cycle_gas,--,"{true, false}",Add option to include `Allam cycle gas power plants <https://en.wikipedia.org/wiki/Allam_power_cycle>`_
 hydrogen_fuel_cell,--,"{true, false}",Add option to include hydrogen fuel cell for re-electrification. Assuming OCGT technology costs

--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -105,6 +105,7 @@ storage_units,--,List of storage technologies to include as StorageUnit componen
 methanation,--,"{true, false}",Add option for transforming hydrogen and CO2 into methane using methanation.
 coal_cc,--,"{true, false}",Add option for coal CHPs with carbon capture
 dac,--,"{true, false}",Add option for Direct Air Capture (DAC)
+dac_limit,--,float or false,Add limit on Direct Air Capture (DAC). Can be either false or limit in MtCO2.
 co2_vent,--,"{true, false}",Add option for vent out CO2 from storages to the atmosphere.
 allam_cycle_gas,--,"{true, false}",Add option to include `Allam cycle gas power plants <https://en.wikipedia.org/wiki/Allam_power_cycle>`_
 hydrogen_fuel_cell,--,"{true, false}",Add option to include hydrogen fuel cell for re-electrification. Assuming OCGT technology costs

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,8 @@ Release Notes
 Upcoming Release
 ================
 
+* Added option to include an exogenous DAC limit specified via the configuration file
+
 * Added Iron-Air battery storage technology and changed nomenclature for lithium-ion battery storages from ``battery`` to ``li-ion battery``.
 
 * Feature: Allow CHPs to use different fuel sources such as gas, oil, coal, and methanol. Note that the cost assumptions are based on a gas CHP.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,7 +11,7 @@ Release Notes
 Upcoming Release
 ================
 
-* Added option to include an exogenous DAC limit specified via the configuration file
+* Added option to include an exogenous DAC yearly limit specified via the configuration file (in MtCO2)
 
 * Added Iron-Air battery storage technology and changed nomenclature for lithium-ion battery storages from ``battery`` to ``li-ion battery``.
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -933,11 +933,11 @@ def add_co2_atmosphere_constraint(n, snapshots):
 
 def add_dac_limit(n):
     """
-    Limit the amount of CO2 captured using DAC. The constraint is formulated tCO2.
+    Limit the amount of CO2 captured using DAC. The constraint is formulated in tCO2.
     """
-    dac=n.links.query("Link.str.contains('DAC')")
-    lhs=(n.model["Link-p"].loc[:, dac.index] * n.snapshot_weightings.generators * dac.efficiency2 * -1).sum()
-    rhs=20*1e6  #  ToDo Add a configuration
+    dac = n.links.query("Link.str.contains('DAC')")
+    lhs = (n.model["Link-p"].loc[:, dac.index] * n.snapshot_weightings.generators * dac.efficiency2 * -1).sum()
+    rhs = n.config["sector"]["dac_limit"] * 1e6  # DAC limit specified in config in MtCO2
     n.model.add_constraints(lhs <= rhs, name="DAC limit")
 
 
@@ -976,7 +976,8 @@ def extra_functionality(n, snapshots):
     add_battery_constraints(n)
     add_lossy_bidirectional_link_constraints(n)
     add_pipe_retrofit_constraint(n)
-    add_dac_limit(n)
+    if config["sector"]["dac"] and config["sector"]["dac_limit"]:
+        add_dac_limit(n)
     if n._multi_invest:
         add_carbon_constraint(n, snapshots)
         add_carbon_budget_constraint(n, snapshots)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -937,7 +937,8 @@ def add_dac_limit(n):
     """
     dac = n.links.query("Link.str.contains('DAC')")
     lhs = (n.model["Link-p"].loc[:, dac.index] * n.snapshot_weightings.generators * dac.efficiency2 * -1).sum()
-    rhs = n.config["sector"]["dac_limit"] * 1e6  # DAC limit specified in config in MtCO2
+    optimization_year = int(snakemake.wildcards.planning_horizons)
+    rhs = n.config["sector"]["dac_limit"][optimization_year] * 1e6  # DAC limit specified in config in MtCO2
     n.model.add_constraints(lhs <= rhs, name="DAC limit")
 
 
@@ -976,7 +977,7 @@ def extra_functionality(n, snapshots):
     add_battery_constraints(n)
     add_lossy_bidirectional_link_constraints(n)
     add_pipe_retrofit_constraint(n)
-    if config["sector"]["dac"] and config["sector"]["dac_limit"]:
+    if config["sector"]["dac"] and config["sector"]["dac_limit"]["enable"]:
         add_dac_limit(n)
     if n._multi_invest:
         add_carbon_constraint(n, snapshots)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -931,6 +931,13 @@ def add_co2_atmosphere_constraint(n, snapshots):
             n.model.add_constraints(lhs <= rhs, name=f"GlobalConstraint-{name}")
 
 
+def add_dac_limit(n):
+    dac=n.links.query("Link.str.contains('DAC')")
+    lhs=(n.model["Link-p"].loc[:, dac.index] * n.snapshot_weightings.generators).sum()
+    rhs=20*1e6 / dac.efficiency2.mean() * -1
+    n.model.add_constraints(lhs <= rhs, name="DAC limit")
+
+
 def extra_functionality(n, snapshots):
     """
     Collects supplementary constraints which will be passed to
@@ -966,6 +973,7 @@ def extra_functionality(n, snapshots):
     add_battery_constraints(n)
     add_lossy_bidirectional_link_constraints(n)
     add_pipe_retrofit_constraint(n)
+    add_dac_limit(n)
     if n._multi_invest:
         add_carbon_constraint(n, snapshots)
         add_carbon_budget_constraint(n, snapshots)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -932,9 +932,12 @@ def add_co2_atmosphere_constraint(n, snapshots):
 
 
 def add_dac_limit(n):
+    """
+    Limit the amount of CO2 captured using DAC. The constraint is formulated tCO2.
+    """
     dac=n.links.query("Link.str.contains('DAC')")
-    lhs=(n.model["Link-p"].loc[:, dac.index] * n.snapshot_weightings.generators).sum()
-    rhs=20*1e6 / dac.efficiency2.mean() * -1
+    lhs=(n.model["Link-p"].loc[:, dac.index] * n.snapshot_weightings.generators * dac.efficiency2 * -1).sum()
+    rhs=20*1e6  #  ToDo Add a configuration
     n.model.add_constraints(lhs <= rhs, name="DAC limit")
 
 


### PR DESCRIPTION
Closes https://github.com/open-energy-transition/form-energy-storage/issues/41.

## Changes proposed in this Pull Request

Suggest a constraint to limit DAC usage.

The current model configuration considers only a subset of sectors. The fuel shares of the transport demand are defined exogenously. This leads to incompressible emissions from land transport oil (366 MtCO2) and associated oil refining (19 Mt CO2). The current CO2 limit is 371 Mt CO2,  which is lower than the land transport emissions (385 Mt CO2). This represents a gap of 14 MtCO2.

The current scenario must be designed so that the CO2 from DAC is not used by Sabatier to produce e-methane. Of the 130 MtCO2 currently captured by DAC, 39 MtCO2 is used by Sabatier and the rest is sequestered (100 Mt CO2).

Completely disabling DAC is not an option because of the transport emissions. This PR proposes to limit the CO2 captured by DAC to 20 MtCO2 (slightly more than the 14 Mt CO2 gap).

A 20 MtCO2 limit for DAC is optimistic but relates to the [European Commission Industrial Carbon Management (COM/2024/62)](https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:52024DC0062).

![image](https://github.com/user-attachments/assets/9787b0b7-77b9-42f8-a236-723ad36a5d0e)

A 50 MtCO2 target is given for 2030 and 280 MtCO2 for 2040. Interpolating this for 2035 gives 165 MtCO2. As 25% of it is projected to be capture by DAC in 2040, a 12.5% target is assumed in 2035. This gives a 20.6 MtCO2 target for 2035 ( `(50 + (280 - 50) / 2) * 0.25 / 2)`).

We are aware that is a raw approximation giving only an order of magnitude. Geographical scopes are not aligned neither as the current version of the model doesn't consider all the EU countries.

[European Commission Framework for Carbon removals](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=COM%3A2022%3A672%3AFIN&qid=1669907104132) also gives a lower bound of 5MtCO2 being removed using industrial technologies by 2030.

# ToDo
- [x] Avoid hard coded values, define a configuration
- [x] Improve documentation of the code

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
