### PR TITLE
Transmission project year filter

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -329,6 +329,7 @@ transmission_projects:
     #- planned_not_yet_permitted
     #- under_consideration
   new_link_capacity: zero #keep or zero
+  filter_year: 2050
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#transformers
 transformers:

--- a/doc/configtables/transmission_projects.csv
+++ b/doc/configtables/transmission_projects.csv
@@ -7,3 +7,4 @@ include,--,,"Name of the transmission projects. They should be unique and have t
 skip,list,,"Type of lines to skip from all transmission projects. Possible values are: ``upgraded_lines``, ``upgraded_links``, ``new_lines``, ``new_links``."
 status,list or dict,,"Status to include into the model as list or as dict with name of project and status to include. Possible values for status are ``under_construction``, ``in_permitting``, ``confirmed``, ``planned_not_yet_permitted``, ``under_consideration``."
 new_link_capacity,--,"{zero,keep}",Whether to set the new link capacity to the provided capacity or set it to zero.
+filter_year,--,{YYYY},Year to filter transmission project build year for including the given year.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,8 @@ Upcoming Release
 ================
 
 
+* Improve transmission_projects by adding a configuration parameter ``filter_year`` that lets you filter for projects with a build year up until and including a given year.
+
 * Feature: Add `Plot_KPIs` which generates both predefined and configurable results figures from ``config/config.kpi.yaml``. To generate those figures, use the rule``plot_KPIs_all``.
 
 * Added option to include an exogenous DAC yearly limit specified via the configuration file (in MtCO2)

--- a/scripts/add_transmission_projects_and_dlr.py
+++ b/scripts/add_transmission_projects_and_dlr.py
@@ -75,13 +75,7 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
-        snakemake = mock_snakemake("add_transmission_projects_and_dlr",
-                                   opts="",
-                                   clusters="52",
-                                   ll="v1.11",
-                                   sector_opts="",
-                                   run="baseline-neplinesandlinks"
-                                   )
+        snakemake = mock_snakemake("add_transmission_projects_and_dlr")
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 

--- a/scripts/add_transmission_projects_and_dlr.py
+++ b/scripts/add_transmission_projects_and_dlr.py
@@ -24,13 +24,16 @@ def attach_transmission_projects(
     for path in transmission_projects:
         path = Path(path)
         df = pd.read_csv(path, index_col=0, dtype={"bus0": str, "bus1": str})
+        filter_year = params.get("transmission_projects").get("filter_year", np.inf)
         if df.empty:
             continue
         if "new_buses" in path.name:
             n.add("Bus", df.index, **df)
         elif "new_lines" in path.name:
+            df.query("build_year <= @filter_year", inplace=True)
             n.add("Line", df.index, **df)
         elif "new_links" in path.name:
+            df.query("build_year <= @filter_year", inplace=True)
             n.add("Link", df.index, **df)
         elif "adjust_lines" in path.name:
             n.lines.update(df)
@@ -72,7 +75,13 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
-        snakemake = mock_snakemake("add_transmission_projects_and_dlr")
+        snakemake = mock_snakemake("add_transmission_projects_and_dlr",
+                                   opts="",
+                                   clusters="52",
+                                   ll="v1.11",
+                                   sector_opts="",
+                                   run="baseline-neplinesandlinks"
+                                   )
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 


### PR DESCRIPTION
This PR adds a `filter_year` configuration option that is used in add_transmission_projects.py to filter out projects that have a build_year until and including the given filter_year.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
